### PR TITLE
Make AutoBindShader::Compute::shader() return GLBaseShader

### DIFF
--- a/src/LibSL/GLHelpers/AutoBindShader.h
+++ b/src/LibSL/GLHelpers/AutoBindShader.h
@@ -136,7 +136,7 @@ namespace AutoBindShader {
       m_FirstInit = true;
       m_WriteShaderFiles = false;
     }
-    LibSL::GLHelpers::GLShader& shader()                  { return m_Shader;  }
+    LibSL::GLHelpers::GLBaseShader& shader()                  { return m_Shader;  }
     void    setWriteShaderFiles(bool b) { m_WriteShaderFiles = b; }
 
     void	  begin() { m_Shader.begin(); T_Precompiled::commitTweaks(); }


### PR DESCRIPTION
Since T_Precompiled is apparently GLHelpers::GLCompute, then shader()
must return its base class, GLBaseShader (instead of GLShader). This
fixes an "invalid initialization of reference..." error.