### PR TITLE
Set a default title for SimpleUI glfw and GLUT backends

### DIFF
--- a/src/LibSL/UIHelpers/SimpleUI_glfw.cpp
+++ b/src/LibSL/UIHelpers/SimpleUI_glfw.cpp
@@ -235,6 +235,11 @@ void NAMESPACE::init(uint width,uint height, const char *title,char **argv, int 
   glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_FALSE);
 #endif
 
+  // set a default title
+  if (title == NULL) {
+    title = "LibSL::SimpleUI (GLFW)";
+  }
+
   // window creation
   if (fullscreen) {
     GLFWmonitor* monitor = glfwGetPrimaryMonitor();

--- a/src/LibSL/UIHelpers/SimpleUI_glut.cpp
+++ b/src/LibSL/UIHelpers/SimpleUI_glut.cpp
@@ -213,6 +213,11 @@ void NAMESPACE::init(uint width,uint height,const char *title,char **argv,int ar
   sl_assert(!frameLess);  // not supported
   sl_assert(!fullscreen); // not supported
 
+  // set a default title
+  if (title == NULL) {
+    title = "LibSL::SimpleUI (GLUT)";
+  }
+
   glutInit              (&argc, argv);
 
 #ifdef OPENGLCORE


### PR DESCRIPTION
This fixes a crash with freeglut3 when calling glutCreateWindow(NULL).