### PR TITLE
Add GLCompute run version with glDispatchComputeGroupSizeARB

### DIFF
--- a/src/LibSL/GLHelpers/AutoBindShader.h
+++ b/src/LibSL/GLHelpers/AutoBindShader.h
@@ -140,6 +140,9 @@ namespace AutoBindShader {
     void	  end()	  { m_Shader.end();   }
 
     void	  run(const LibSL::Math::v3i& numGroups)	{ m_Shader.run(numGroups); }
+#if OPENGL4
+    void	  run(const LibSL::Math::v3i& numGroups, const LibSL::Math::v3i& groupSize)	{ m_Shader.run(numGroups, groupSize); }
+#endif
 
 #ifdef TW_INCLUDED
     TwBar *makeTwBar() { return T_Precompiled::makeTwBar(this); }

--- a/src/LibSL/GLHelpers/GLHelpers.cpp
+++ b/src/LibSL/GLHelpers/GLHelpers.cpp
@@ -866,6 +866,17 @@ void NAMESPACE::GLCompute::run(const v3i& numGroups)
 	glDispatchCompute(numGroups[0],numGroups[1],numGroups[2]);
 }
 
+#if OPENGL4
+void NAMESPACE::GLCompute::run(const v3i& numGroups, const v3i& groupSize)
+{
+    authorize();
+	if (!m_Active)
+		throw GLException("GLCompute::run - must be enclosed in-between begin/end calls");
+	glDispatchComputeGroupSizeARB(numGroups[0],numGroups[1],numGroups[2],
+				      groupSize[0],groupSize[1],groupSize[2]);
+}
+#endif
+
 // -----------------------------------------------------
 
 #endif

--- a/src/LibSL/GLHelpers/GLHelpers.h
+++ b/src/LibSL/GLHelpers/GLHelpers.h
@@ -106,6 +106,7 @@ using namespace LibSL::System::Types;
 #include "GL_ARB_shader_atomic_counters.h"
 #include "GL_ARB_compute_shader.h"
 #include "GL_ARB_copy_buffer.h"
+#include "GL_ARB_compute_variable_group_size.h"
 #include "GL_VERSION_3_0.h"
 #include "GL_VERSION_3_1.h"
 #include "GL_VERSION_3_2.h"
@@ -565,6 +566,9 @@ namespace LibSL {
 			void init(GLuint shader);
 
 			void run(const LibSL::Math::v3i& numGroups);
+#if OPENGL4
+			void run(const LibSL::Math::v3i& numGroups, const LibSL::Math::v3i& groupSize);
+#endif
 
 			void terminate();
 


### PR DESCRIPTION
This PR adds support for ARB_compute_variable_group_size in the GLCompute wrapper class. It allows OpenGL 4 contexts to run compute shaders with a local group size which is chosen at run-time instead of hard-coded in the shader source.