### PR TITLE
Fix 'turntable' trackball mechanics

### DIFF
--- a/src/LibSL/UIHelpers/Trackball.h
+++ b/src/LibSL/UIHelpers/Trackball.h
@@ -62,25 +62,29 @@ namespace LibSL {
       typedef LibSL::Math::quatf quatf;
       typedef LibSL::Math::v3f   v3f;
 
+      // previous x and y screen-space positions
+      int   m_PrevX;
+      int   m_PrevY;
+
+      // screen dimensions in pixels
+      uint  m_Width;
+      uint  m_Height;
+
       quatf m_Rotation;
       v3f   m_Translation;
       v3f   m_Center;
-      uint  m_Width;
-      uint  m_Height;
-      int   m_PrevX;
-      int   m_PrevY;
       float m_Elapsed;
       uint  m_Status;
       float m_Radius;
       bool  m_Walkthrough;
-			bool  m_AllowRoll;
+      bool  m_AllowRoll; // if false use 'turntable' navigation
       float m_WalkDir;
       float m_WalkSide;
       float m_WalkSpeed;
       float m_BallSpeed;
       bool  m_Locked;
       bool  m_ForceZoom;
-      e_Direction m_Up;      
+      e_Direction m_Up;
 
       void  initRotation(uint x,uint y);
       void  initTranslation(uint x,uint y);


### PR DESCRIPTION
Currently the Trackball has a strange behavior when the camera direction is parallel to the "up" direction: any small movement will cause the camera to spin very fast around the up direction. 

I fixed this by implementing true "turntable" camera mechanics, inspired by how it is implemented in e.g. [Polyscope](https://github.com/nmwsharp/polyscope/blob/master/src/view.cpp#L71).

This change shouldn't have affected any other parts of the library, however i was unable to test it against the m_Walkthrough flag as i don't know how it is meant to be used or what it is supposed to exactly do.